### PR TITLE
Error handler exits with error code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,7 @@ function built(file) {
 
 function error(error) {
 	console.log(colors.red('Error: ') + (error.codeFrame || error));
+	process.exit(1);
 }
 
 function processFiles(processor, options) {


### PR DESCRIPTION
This pull requests changes the error handler so that gluten exits with an error code instead of just printing the error to the console.

This change is designed to ensure that a Jenkins job fails if glue encounters an error.  Currently, errors are logged to the console, and no error code is returned, which can result in a Jenkins build SUCCESS even though there are Javascript build errors.
